### PR TITLE
Give third party disabled warning TOML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ lib1.files = [
   'pkg1.vhd',
   'tb_ent.vhd',
 ]
+
+# Libraries can be marked as third-party to disable some analysis warnings, such as unused declarations
+UNISIM.files = [
+  'C:\Xilinx\Vivado\2023.1\data\vhdl\src\unisims\unisim_VCOMP.vhd',
+]
+UNISIM.is_third_party = true
 ```
 
 ## Technology under the hood


### PR DESCRIPTION
Expose new feature in documentation, as well as raising awareness of how to support Xilinx projects.

Similar to VHDL-LS/rust_hdl#223