### PR TITLE
Make indentationRules case-insensitive (#81)

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -17,7 +17,13 @@
         ["\\", "\\"]
     ],
     "indentationRules": {
-        "increaseIndentPattern": "\\b(begin|is|port|else|loop|generate|then)\\b",
-        "decreaseIndentPattern": "^\\s*(elsif|else|end|begin)\\b"
+        "increaseIndentPattern": {
+            "pattern": "\\b(begin|is|port|else|loop|generate|then)\\b",
+            "flags": "i"
+        },
+        "decreaseIndentPattern": {
+            "pattern": "^\\s*(elsif|else|end|begin)\\b",
+            "flags": "i"
+        }
     }
 }


### PR DESCRIPTION
indentationRules determine if the next line is indented whenever you press enter. These are case sensitive by default (triggering on lower-case only), which does not work well if you write VHDL with upper-case keywords. VHDL itself is not case sensitive.

This pull requests makes the rules case-insensitive.