### PR TITLE
Fix missing `protected` keyword

### DIFF
--- a/syntaxes/vhdl.tmLanguage
+++ b/syntaxes/vhdl.tmLanguage
@@ -221,7 +221,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?i:abs|access|after|alias|all|and|architecture|array|assert|attribute|begin|block|body|buffer|bus|component|configuration|constant|context|default|disconnect|downto|else|elsif|end|entity|exit|file|for|function|generate|generic|group|guarded|if|impure|in|inertial|inout|is|label|library|linkage|literal|loop|map|mod|nand|new|next|nor|not|null|of|on|open|or|others|out|package|port|postponed|private|procedure|process|pure|range|record|register|reject|rem|report|return|rol|ror|select|severity|shared|signal|sla|sll|sra|srl|subtype|then|to|transport|type|unaffected|units|until|use|variable|view|wait|when|while|with|xnor|xor)\b</string>
+					<string>\b(?i:abs|access|after|alias|all|and|architecture|array|assert|attribute|begin|block|body|buffer|bus|component|configuration|constant|context|default|disconnect|downto|else|elsif|end|entity|exit|file|for|function|generate|generic|group|guarded|if|impure|in|inertial|inout|is|label|library|linkage|literal|loop|map|mod|nand|new|next|nor|not|null|of|on|open|or|others|out|package|port|postponed|private|procedure|process|protected|pure|range|record|register|reject|rem|report|return|rol|ror|select|severity|shared|signal|sla|sll|sra|srl|subtype|then|to|transport|type|unaffected|units|until|use|variable|view|wait|when|while|with|xnor|xor)\b</string>
 					<key>name</key>
 					<string>keyword.control.language.vhdl</string>
 				</dict>


### PR DESCRIPTION
The keyword `protected` was not highlighted in VS Code. This commit fixes it.